### PR TITLE
adding support for pipeline projects

### DIFF
--- a/src/main/java/org/jenkins/ci/plugins/JobPollTransientProjectActionFactory.java
+++ b/src/main/java/org/jenkins/ci/plugins/JobPollTransientProjectActionFactory.java
@@ -1,18 +1,18 @@
 /*
  * The MIT License
- * 
+ *
  * Copyright (c) 2012, Jesse Farinacci
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,8 +26,8 @@ package org.jenkins.ci.plugins;
 
 import hudson.Extension;
 import hudson.model.Action;
-import hudson.model.TransientProjectActionFactory;
-import hudson.model.AbstractProject;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,16 +36,21 @@ import java.util.Collections;
  * A very simple {@link hudson.model.TransientProjectActionFactory} which
  * creates new {@link JobPollAction}s for the target
  * {@link hudson.model.AbstractProject}.
- * 
+ *
  * @author <a href="mailto:jieryn@gmail.com">Jesse Farinacci</a>
  * @since 1.0
  */
 @Extension
 public final class JobPollTransientProjectActionFactory extends
-        TransientProjectActionFactory {
+TransientActionFactory<Job> {
     @Override
     public Collection<? extends Action> createFor(
-            @SuppressWarnings("rawtypes") final AbstractProject target) {
+            @SuppressWarnings("rawtypes") final Job target) {
         return Collections.singleton(new JobPollAction(target));
     }
+
+	@Override
+	public Class<Job> type() {
+		return Job.class;
+	}
 }

--- a/src/main/resources/org/jenkins/ci/plugins/JobPollAction/action.jelly
+++ b/src/main/resources/org/jenkins/ci/plugins/JobPollAction/action.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<j:if test="${h.hasPermission(it,it.BUILD) and from.pollingEnabled}">
-		<l:task icon="${h.getIconFilePath(from)}" title="${from.displayName}" href="/job/${from.targetName}/poll" />
+		<l:task icon="${h.getIconFilePath(from)}" title="${from.displayName}" href="${rootURL}/${from.url}/poll" />
 	</j:if>
 </j:jelly>

--- a/src/main/resources/org/jenkins/ci/plugins/JobPollAction/index.jelly
+++ b/src/main/resources/org/jenkins/ci/plugins/JobPollAction/index.jelly
@@ -32,7 +32,7 @@ THE SOFTWARE.
         	 <img src="${imagesURL}/spinner.gif" alt="" />
         </span>
       </h1>
-        
+
       <j:set var="log" value="${it.logText}" />
       <pre id="pollLog">
 	     <st:getOutput var="output" />
@@ -40,13 +40,13 @@ THE SOFTWARE.
 			 <j:whitespace>${it.writeLogTo(output)}</j:whitespace>
 		 </j:if>
       </pre>
-        	 
+
         <script>
 			function doSCMPoll() {
-				new Ajax.Request("/job/${it.owner.name}/polling/", {});
-				
+				new Ajax.Request("${rootURL}/${it.owner.url}/polling/", {});
+
 				var pollingFunction = function f() {
-			    	new Ajax.Request("/job/${it.owner.name}/poll/log/", {
+			    	new Ajax.Request("${rootURL}/${it.owner.url}/poll/log/", {
 				    		onSuccess: function(rsp) {
 				    			if(rsp.responseText.search("Done. Took") &lt; 0) {
 				    				setTimeout(f, 1000);
@@ -56,15 +56,15 @@ THE SOFTWARE.
 				    			$$("pollLog").innerHTML = rsp.responseText;
 				    		}
 			    		});
-			    };	
-			    
+			    };
+
 			    setTimeout(pollingFunction, 1000);
-			    
+
 			}
-			
+
 			doSCMPoll();
 		</script>
-      
+
     </l:main-panel>
   </l:layout>
 </j:jelly>


### PR DESCRIPTION

The plugin will now work for pipeline projects.
The code is unchanged for all job types that extend AbstractProject.

For all other types that extend Job, it uses reflection to access SCM objects to determine if polling is enabled. So there are no new dependencies required on workflow (pipeline) plugins.
